### PR TITLE
Fix bug with repo uninstalls

### DIFF
--- a/lib/custodian/github/processor.ex
+++ b/lib/custodian/github/processor.ex
@@ -40,7 +40,7 @@ defmodule Custodian.Github.Processor do
     create_bots(params["installation"]["id"], params["repositories_added"])
   end
 
-  def installation(%{"action" => "deleted"} = params) do
+  def installation(%{"action" => "removed"} = params) do
     Appsignal.increment_counter("event_installation_deleted_count", 1)
     Appsignal.increment_counter("bot_count", -1)
     bot = Bots.get_bot_by!(installation_id: params["installation"]["id"])

--- a/test/custodian/github/processor_test.exs
+++ b/test/custodian/github/processor_test.exs
@@ -66,7 +66,7 @@ defmodule Custodian.Github.ProcessorTest do
     })
 
     params = %{
-      "action" => "deleted",
+      "action" => "removed",
       "installation" => %{"id" => 1}
     }
 


### PR DESCRIPTION
The JSON payload has `"action": "removed"` and not `deleted`. This was
causing errors.