### PR TITLE
Update repo uninstall to look up by repo_id instead of installation_id

### DIFF
--- a/test/custodian/github/processor_test.exs
+++ b/test/custodian/github/processor_test.exs
@@ -65,13 +65,20 @@ defmodule Custodian.Github.ProcessorTest do
       installation_id: 1
     })
 
+    Bots.create_bot(%{
+      repo_id: 2,
+      owner: "lleger",
+      name: "gh-api-test1",
+      installation_id: 1
+    })
+
     params = %{
       "action" => "removed",
-      "installation" => %{"id" => 1}
+      "repositories_removed" => [%{"id" => 1}, %{"id" => 2}]
     }
 
     assert {:ok, bot} = Processor.installation(params)
-    assert_raise Ecto.NoResultsError, fn -> Bots.get_bot!(bot.id) end
+    assert Bots.list_bots() == []
   end
 
   test "labels pr when opened" do


### PR DESCRIPTION
Several repos could be installed by the same installation_id. Removing a
single one in this case threw an error since `Bots.get_by/1` returned
more than one result.

The proper way to handle this is to iterate over the repositories that
need to be removed and do so by their repo_id instead.